### PR TITLE
Bump commons-collections4 from 4.0 to 4.1 in /app

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Bumps commons-collections4 from 4.0 to 4.1.

Signed-off-by: dependabot[bot] <support@github.com>