### PR TITLE
Bump commons-io from 2.4 to 2.7 in /app

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 		</dependency>
 
 		<!-- Vuln Method libs -->


### PR DESCRIPTION
Bumps commons-io from 2.4 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>